### PR TITLE
Cli fix

### DIFF
--- a/shongo-client-cli/src/main/perl/Shongo/ClientCli/Shell.pm
+++ b/shongo-client-cli/src/main/perl/Shongo/ClientCli/Shell.pm
@@ -27,8 +27,7 @@ use Shongo::Test;
 sub new
 {
     my $class = shift;
-    my $disable_term = shift;
-    my $self = Shongo::Shell->new('controller', $disable_term);
+    my $self = Shongo::Shell->new('controller');
 
     $self->prompt('shongo> ');
     $self->add_commands({

--- a/shongo-client-cli/src/main/perl/Shongo/Console.pm
+++ b/shongo-client-cli/src/main/perl/Shongo/Console.pm
@@ -32,6 +32,29 @@ BEGIN {
 use Term::ReadKey;
 use Shongo::Common;
 
+# One single terminal for the whole application
+my $term;
+
+#
+# Return single terminal
+# Initialize terminal if it is not initialized yet
+#
+# Single terminal has to be used for version >= 1.46
+# https://metacpan.org/release/HAYASHI/Term-ReadLine-Gnu-1.46
+#
+# @return initialized terminal
+#
+sub get_term
+{
+    if ( !defined($term) ) {
+        $term = Term::ReadLine->new('read_line');
+        $term->ornaments(0);
+        $term->SetHistory();
+    }
+
+    return $term;
+}
+
 #
 # Print text
 #
@@ -217,9 +240,6 @@ sub console_print_table
 sub console_read
 {
     my ($message, $value) = @_;
-    my $term = Term::ReadLine->new('read_line');
-    $term->ornaments(0);
-    $term->SetHistory();
     my $line = $term->readline(colored(sprintf("%s: ", $message), "bold blue"), $value);
     utf8::decode($line);
     return $line;

--- a/shongo-client-cli/src/main/perl/Shongo/Shell.pm
+++ b/shongo-client-cli/src/main/perl/Shongo/Shell.pm
@@ -21,12 +21,13 @@ sub new
 {
     my $class = shift;
     my $name = shift;
-    my $disable_term = shift;
+
+    my $term = Shongo::Console::get_term();
     my $self = Term::ShellUI->new(@_,
         commands => {},
         name => $name,
         backslash_continues_command => 1,
-        disable_term => $disable_term
+        term => $term,
     );
 
     if ( defined($self->{'term'}) ) {


### PR DESCRIPTION
Fix client-cli to use single Term::ReadLine.

The single terminal has to be used for version >= 1.46
https://metacpan.org/release/HAYASHI/Term-ReadLine-Gnu-1.46
